### PR TITLE
don't require integer vertices

### DIFF
--- a/lib/graph_matching/graph/graph.rb
+++ b/lib/graph_matching/graph/graph.rb
@@ -12,15 +12,6 @@ module GraphMatching
   module Graph
     # Base class for all graphs.
     class Graph < RGL::AdjacencyGraph
-      def self.[](*args)
-        super.tap(&:vertexes_must_be_integers)
-      end
-
-      def initialize(*args)
-        super
-        vertexes_must_be_integers
-      end
-
       # `adjacent_vertex_set` is the same as `adjacent_vertices`
       # except it returns a `Set` instead of an `Array`.  This is
       # an optimization, performing in O(n), whereas passing
@@ -52,11 +43,6 @@ module GraphMatching
 
       def vertexes
         to_a
-      end
-
-      def vertexes_must_be_integers
-        return if vertices.none? { |v| !v.is_a?(Integer) }
-        raise ArgumentError, 'All vertexes must be integers'
       end
     end
   end

--- a/lib/graph_matching/graph/weighted.rb
+++ b/lib/graph_matching/graph/weighted.rb
@@ -67,7 +67,6 @@ module GraphMatching
         def weighted_edge?(e)
           e.is_a?(Array) &&
             e.length == 3 &&
-            e[0, 2].all? { |i| i.is_a?(Integer) } &&
             e[2].is_a?(Integer) || e[2].is_a?(Float)
         end
       end


### PR DESCRIPTION
I'd like to remove the check that the vertices are integers. Theoretically, vertices only need be able to have some sort of equality function.